### PR TITLE
Setup Screen Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ On MSX pressing `CTRL-U` will reset the computer, if a ROM file was downloaded t
 
 ## 2.1 Setup screen
 
-A simple setup screen can be accessed by pressing `CBM + F7` (Commodore) or `CTRL-F5` (MSX), pressing `F1` will exit back to the terminal.
+A simple setup screen can be accessed by pressing `F7` or `CTRL-F5` (MSX), pressing `F1` will exit back to the terminal.
 
 The first setting, common to all _Retroterm_ variants sets the **RTS** pulse width. Current values are known to work under VICE, or on real hardware with an userport modem using Zimodem firmware, and with the Ultimate Swiftlink emulation.
 Use the `+` and `-` keys to adjust.

--- a/source/retroterm_univ.asm
+++ b/source/retroterm_univ.asm
@@ -1978,11 +1978,11 @@ ChkKey
 	EOR $07F8
 	STA $07F8
 	BNE ExitIrq
-+	CMP #$8C			; F8?
++	CMP #$88			; F7?
 	BNE +
-	LDX $028D			; Shift Keys flag
-	CPX #$02			; C= pressed?
-	BNE +
+;	LDX $028D			; Shift Keys flag
+;	CPX #$02			; C= pressed?
+;	BNE +
 	;Test terminal not in command mode
 	BIT CMDFlags
 	BVS ExitIrq


### PR DESCRIPTION
@retrocomputacion,
do you mind changing the setup screen invoke from a CBM + F7 keypress to a simpler F7 keypress ?

Also in [VICE](https://vice-emu.sourceforge.io/) Emulator the existing keystroke doesn't work in 'symbolic' Keymap but works in 'positional' map. Reason i don't know.
In my C64 FPGA implementation (adapted MISTer core) the setup screen can't be opened by CBM + F7 and i am looking for a solution.  
